### PR TITLE
Modified year format and fixed naming of message constraints for Credit, Grade, and year

### DIFF
--- a/src/main/java/seedu/address/model/module/Credit.java
+++ b/src/main/java/seedu/address/model/module/Credit.java
@@ -13,7 +13,7 @@ public class Credit {
     /**
      * Describes the requirements for credit value.
      */
-    public static final String MESSAGE_CODE_CONSTRAINTS = "Credits must be a integer";
+    public static final String MESSAGE_CREDIT_CONSTRAINTS = "Credits must be a integer";
 
     /**
      * Immutable credit value.
@@ -21,13 +21,13 @@ public class Credit {
     public final int value;
 
     /**
-     * Constructs an {@code Code}.
+     * Constructs an {@code Credit}.
      *
      * @param credits A valid credit.
      */
     public Credit(int credits) {
         requireNonNull(credits);
-        checkArgument(isValidCredit(credits), MESSAGE_CODE_CONSTRAINTS);
+        checkArgument(isValidCredit(credits), MESSAGE_CREDIT_CONSTRAINTS);
         value = credits;
     }
 

--- a/src/main/java/seedu/address/model/module/Grade.java
+++ b/src/main/java/seedu/address/model/module/Grade.java
@@ -13,7 +13,7 @@ public class Grade {
     /**
      * Describes the requirements for grade value.
      */
-    public static final String MESSAGE_CODE_CONSTRAINTS =
+    public static final String MESSAGE_GRADE_CONSTRAINTS =
             "Grade can be A+, A, A-, B+, B, B-, C+, C, D+, D, F, CS, CU";
 
     /**
@@ -34,7 +34,7 @@ public class Grade {
      */
     public Grade(String grade) {
         requireNonNull(grade);
-        checkArgument(isValidGrade(grade), MESSAGE_CODE_CONSTRAINTS);
+        checkArgument(isValidGrade(grade), MESSAGE_GRADE_CONSTRAINTS);
         value = grade;
     }
 

--- a/src/main/java/seedu/address/model/module/Year.java
+++ b/src/main/java/seedu/address/model/module/Year.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Year {
 
-    public static final String MESSAGE_CODE_CONSTRAINTS =
+    public static final String MESSAGE_YEAR_CONSTRAINTS =
             "Year must be [1-2][0-9][1-2][0-9]. Example: 1819 represents YA 2018/2019";
 
     /**
@@ -24,13 +24,13 @@ public class Year {
     public final int value;
 
     /**
-     * Constructs an {@code Code}.
+     * Constructs an {@code Year}.
      *
      * @param year A valid year.
      */
     public Year(int year) {
         requireNonNull(year);
-        checkArgument(isValidYear(year), MESSAGE_CODE_CONSTRAINTS);
+        checkArgument(isValidYear(year), MESSAGE_YEAR_CONSTRAINTS);
         value = Integer.valueOf(year);
     }
 
@@ -59,7 +59,7 @@ public class Year {
      * <p>
      * This defines a notion of equality between two Year objects.
      *
-     * @param other Code object compared against this object
+     * @param other Year object compared against this object
      * @return true if both are the same object or contains the same value
      */
     @Override

--- a/src/main/java/seedu/address/model/module/Year.java
+++ b/src/main/java/seedu/address/model/module/Year.java
@@ -11,12 +11,12 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Year {
 
     public static final String MESSAGE_YEAR_CONSTRAINTS =
-            "Year must be [1-2][0-9][1-2][0-9]. Example: 1819 represents YA 2018/2019";
+            "Year must be [1-5]. Example: 1 represents Year 1";
 
     /**
      * No whitespace allowed.
      */
-    public static final String YEAR_VALIDATION_REGEX = "[1-2][0-9][1-2][0-9]";
+    public static final String YEAR_VALIDATION_REGEX = "[1-5]";
 
     /**
      * Immutable year value.
@@ -29,6 +29,16 @@ public class Year {
      * @param year A valid year.
      */
     public Year(int year) {
+        checkArgument(isValidYear(year), MESSAGE_YEAR_CONSTRAINTS);
+        value = year;
+    }
+
+    /**
+     * Constructs an {@code Year}.
+     *
+     * @param year A valid year.
+     */
+    public Year(String year) {
         requireNonNull(year);
         checkArgument(isValidYear(year), MESSAGE_YEAR_CONSTRAINTS);
         value = Integer.valueOf(year);
@@ -41,7 +51,17 @@ public class Year {
      * @return true if given string is a valid year
      */
     public static boolean isValidYear(int year) {
-        return Integer.toString(year).matches(YEAR_VALIDATION_REGEX);
+        return isValidYear(Integer.toString(year));
+    }
+
+    /**
+     * Returns true if a given string is a valid year.
+     *
+     * @param year string to be tested for validity
+     * @return true if given string is a valid year
+     */
+    public static boolean isValidYear(String year) {
+        return year.matches(YEAR_VALIDATION_REGEX);
     }
 
     /**

--- a/src/test/java/seedu/address/model/module/ModuleTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleTest.java
@@ -14,6 +14,7 @@ import seedu.address.testutil.Assert;
 import seedu.address.testutil.ModuleBuilder;
 
 public class ModuleTest {
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -95,7 +96,7 @@ public class ModuleTest {
 
     @Test
     public void toStringValid() {
-        assertTrue(DATA_STRUCTURES.toString().contentEquals("Code: CS2040 Year: 1718 Semester: "
-                        + "s1 Credits: 4 Grade: F Completed: true"));
+        assertTrue(DATA_STRUCTURES.toString().contentEquals("Code: CS2040 Year: 3 Semester: "
+                + "s1 Credits: 4 Grade: F Completed: true"));
     }
 }

--- a/src/test/java/seedu/address/model/module/YearTest.java
+++ b/src/test/java/seedu/address/model/module/YearTest.java
@@ -10,33 +10,43 @@ import seedu.address.testutil.Assert;
 public class YearTest {
 
     @Test
+    public void constructorNullThrowsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> new Year(null));
+    }
+
+    @Test
     public void constructorInvalidYearThrowsIllegalArgumentException() {
-        int invalidYear = 1;
-        Assert.assertThrows(IllegalArgumentException.class, () -> new Year(invalidYear));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new Year(0));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new Year("0"));
     }
 
     @Test
     public void isValidYear() {
         // invalid year format
-        assertFalse(Year.isValidYear(1)); // single digit
-        assertFalse(Year.isValidYear(10)); // two digit
-        assertFalse(Year.isValidYear(100)); // three digit
-        assertFalse(Year.isValidYear(1000)); // third digit must be either 1 or 2
+        assertFalse(Year.isValidYear(0)); // year must be at least 1
+        assertFalse(Year.isValidYear(6)); // year must be 5 or below
+        assertFalse(Year.isValidYear(10)); // only 1 digit allowed
 
-        // valid year
-        assertTrue(Year.isValidYear(1010)); // first digit and third digit are both 1
-        assertTrue(Year.isValidYear(1020)); // first digit is 1 and third digit is 2
-        assertTrue(Year.isValidYear(2020)); // first digit and third digit are both 2
-        assertTrue(Year.isValidYear(2010)); // first digit is 2 and third digit is 1
+        // valid year format
+        assertTrue(Year.isValidYear(1)); // year 1
+        assertTrue(Year.isValidYear(2)); // year 2
+        assertTrue(Year.isValidYear(3)); // year 3
+        assertTrue(Year.isValidYear(4)); // year 4
+        assertTrue(Year.isValidYear(5)); // year 5
     }
 
     @Test
     public void toStringValid() {
-        assertTrue(new Year(1819).toString().contentEquals("1819"));
+        assertTrue(new Year(1).toString().contentEquals("1"));
     }
 
     @Test
     public void equalsValid() {
-        assertTrue(new Year(1819).equals(new Year(1819)));
+        assertTrue(new Year(1).equals(new Year(1)));
+    }
+
+    @Test
+    public void hashCodeValid() {
+        assertTrue(new Year(1).hashCode() == "1".hashCode());
     }
 }

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -13,7 +13,7 @@ import seedu.address.model.module.Year;
 public class ModuleBuilder {
 
     public static final String DEFAULT_CODE = "CS2103";
-    public static final int DEFAULT_YEAR = 1819;
+    public static final int DEFAULT_YEAR = 1;
     public static final String DEFAULT_SEMESTER = Semester.SEMESTER_ONE;
     public static final int DEFAULT_CREDIT = 4;
     public static final String DEFAULT_GRADE = "A+";

--- a/src/test/java/seedu/address/testutil/TypicalModules.java
+++ b/src/test/java/seedu/address/testutil/TypicalModules.java
@@ -14,21 +14,21 @@ public class TypicalModules {
     // Manually added
 
     public static final Module DISCRETE_MATH = new ModuleBuilder().withCode("CS1231")
-            .withYear(1819)
+            .withYear(1)
             .withSemester(Semester.SEMESTER_ONE)
             .withCredit(4)
             .withGrade("A+")
             .build();
 
     public static final Module PROGRAMMING_METHODOLOGY_TWO = new ModuleBuilder().withCode("CS2030")
-            .withYear(1920)
+            .withYear(2)
             .withSemester(Semester.SEMESTER_TWO)
             .withCredit(4)
             .withGrade("B")
             .build();
 
     public static final Module DATA_STRUCTURES = new ModuleBuilder().withCode("CS2040")
-            .withYear(1718)
+            .withYear(3)
             .withSemester(Semester.SEMESTER_SPECIAL_ONE)
             .withCredit(4)
             .withGrade("F")


### PR DESCRIPTION
- Previously Year follows the academic year format (e.g. 1819, 1920). Changes have been made as discussed during meeting to use single digit instead (e.g. Year 1 student -> 1, Year 2 student -> 2). 
- Modified test to follow the new year format.
- Fixed naming of message constraint which was wrong previously.