### PR TITLE
Fix module package, added more tests, remove redundant codes

### DIFF
--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -1,5 +1,7 @@
 package seedu.address.model.module;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Objects;
 
 /**
@@ -49,46 +51,13 @@ public class Module {
      */
     private final boolean completed;
 
-    /**
-     * Every field must be present and not null.
-     *
-     * @param code code for the module
-     * @param year year the module was taken
-     * @param semester semester the module was taken
-     * @param credits credits awarded for completion of this module
-     * @param completed true if module has been completed and false if module has not been taken
-     */
-    public Module(String code, int year, String semester, int credits, boolean completed) {
-        this.code = new Code(code);
-        this.year = new Year(year);
-        this.semester = new Semester(semester);
-        this.credits = new Credit(credits);
-        this.grade = null;
-        this.completed = completed;
-    }
-
-    /**
-     * Every field must be present and not null.
-     *
-     * @param code code for the module
-     * @param year year the module was taken
-     * @param semester semester the module was taken
-     * @param credits credits awarded for completion of this module
-     * @param grade grade awarded for completion of this module
-     * @param completed true if module has been completed and false if module has not been taken
-     */
-    public Module(String code, int year, String semester, int credits, String grade,
-            boolean completed) {
-        this.code = new Code(code);
-        this.year = new Year(year);
-        this.semester = new Semester(semester);
-        this.credits = new Credit(credits);
-        this.grade = new Grade(grade);
-        this.completed = completed;
-    }
-
     public Module(Code code, Year year, Semester semester, Credit credit, Grade grade,
             boolean completed) {
+        requireNonNull(code);
+        requireNonNull(year);
+        requireNonNull(semester);
+        requireNonNull(credit);
+
         this.code = code;
         this.year = year;
         this.semester = semester;

--- a/src/main/java/seedu/address/model/module/UniqueModuleList.java
+++ b/src/main/java/seedu/address/model/module/UniqueModuleList.java
@@ -38,7 +38,7 @@ public class UniqueModuleList implements Iterable<Module> {
      */
     public boolean contains(Module toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::equals);
+        return internalList.stream().anyMatch(toCheck::isSameModule);
     }
 
     /**

--- a/src/main/java/seedu/address/model/module/UniqueModuleList.java
+++ b/src/main/java/seedu/address/model/module/UniqueModuleList.java
@@ -143,16 +143,6 @@ public class UniqueModuleList implements Iterable<Module> {
     }
 
     /**
-     * Returns true if two different lists are mutually exclusive.
-     *
-     * @param modules the module list that is compared against
-     * @return true if two different lists are mutually exclusive
-     */
-    public boolean isMutuallyExclusive(List<Module> modules) {
-        return !internalList.stream().anyMatch(modules::contains);
-    }
-
-    /**
      * Returns the iterator of the internal list.
      *
      * @return iterator of the internal list

--- a/src/test/java/seedu/address/model/module/GradeTest.java
+++ b/src/test/java/seedu/address/model/module/GradeTest.java
@@ -30,11 +30,33 @@ public class GradeTest {
 
         // valid grade
         assertTrue(Grade.isValidGrade("A+"));
+        assertTrue(Grade.isValidGrade("A"));
+        assertTrue(Grade.isValidGrade("A-"));
+        assertTrue(Grade.isValidGrade("B+"));
+        assertTrue(Grade.isValidGrade("B"));
+        assertTrue(Grade.isValidGrade("B-"));
+        assertTrue(Grade.isValidGrade("C+"));
+        assertTrue(Grade.isValidGrade("C"));
+        assertTrue(Grade.isValidGrade("D+"));
+        assertTrue(Grade.isValidGrade("D"));
+        assertTrue(Grade.isValidGrade("F"));
+        assertTrue(Grade.isValidGrade("CU"));
+        assertTrue(Grade.isValidGrade("CS"));
     }
 
     @Test
     public void affectCapValid() {
         assertTrue(new Grade("A+").affectsCap());
+        assertTrue(new Grade("A").affectsCap());
+        assertTrue(new Grade("A-").affectsCap());
+        assertTrue(new Grade("B+").affectsCap());
+        assertTrue(new Grade("B").affectsCap());
+        assertTrue(new Grade("B-").affectsCap());
+        assertTrue(new Grade("C+").affectsCap());
+        assertTrue(new Grade("C").affectsCap());
+        assertTrue(new Grade("D+").affectsCap());
+        assertTrue(new Grade("D").affectsCap());
+        assertTrue(new Grade("F").affectsCap());
         assertFalse(new Grade("CS").affectsCap());
         assertFalse(new Grade("CU").affectsCap());
     }
@@ -42,6 +64,16 @@ public class GradeTest {
     @Test
     public void getPointValid() {
         assertTrue(new Grade("A+").getPoint() == 5);
+        assertTrue(new Grade("A").getPoint() == 5);
+        assertTrue(new Grade("A-").getPoint() == 4.5);
+        assertTrue(new Grade("B+").getPoint() == 4.0);
+        assertTrue(new Grade("B").getPoint() == 3.5);
+        assertTrue(new Grade("B-").getPoint() == 3.0);
+        assertTrue(new Grade("C+").getPoint() == 2.5);
+        assertTrue(new Grade("C").getPoint() == 2);
+        assertTrue(new Grade("D+").getPoint() == 1.5);
+        assertTrue(new Grade("D").getPoint() == 1);
+        assertTrue(new Grade("F").getPoint() == 0);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/module/ModuleTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleTest.java
@@ -20,7 +20,7 @@ public class ModuleTest {
     @Test
     public void constructorNullThrowsNullPointerException() {
         Assert.assertThrows(NullPointerException.class, () ->
-                new Module(null, 0, null, 0, false));
+                new Module(null, null, null, null, null, false));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/module/ModuleTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleTest.java
@@ -26,9 +26,9 @@ public class ModuleTest {
     @Test
     public void isSameModule() {
         // same object -> returns true
-        assertTrue(DATA_STRUCTURES.equals(DATA_STRUCTURES));
+        assertTrue(DATA_STRUCTURES.isSameModule(DATA_STRUCTURES));
 
-        // null -> returns false
+        // different object -> returns false
         assertFalse(DATA_STRUCTURES.isSameModule(DISCRETE_MATH));
 
         // different code -> returns false
@@ -47,13 +47,10 @@ public class ModuleTest {
         // same object -> returns true
         assertTrue(DATA_STRUCTURES.equals(DATA_STRUCTURES));
 
-        // null -> returns false
-        assertFalse(DATA_STRUCTURES == null);
-
         // different type -> returns false
         assertFalse(DATA_STRUCTURES.equals(5));
 
-        // different person -> returns false
+        // different module -> returns false
         assertFalse(DATA_STRUCTURES.equals(DISCRETE_MATH));
 
         // different code -> returns false


### PR DESCRIPTION
Added test for:
- `Grade`
- `Module`

Fix:
- `UniqueModuleList`: fixed `contains()`, should use `isSameModule` instead of `equals` for comparison. `isSameModule` only looks at the module code while `equals` look at all fields (year, semester, credit, grade, completed). `UniqueModuleList` should only contain one module with a particular module code.
- `Module`: added `requireNonNull` in constructor. Constructor should not accept null code, year, semester or graded.

Remove:
- `UniqueModuleList.isMutuallyExclusive`: not being used
- `Module.`constructor: Remove redundant constructors, not being used