### PR TITLE
Fix bug for ParserUtil.tokenizer and enforce use of constants in TestUtil.TypicalModules

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,13 +2,12 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-
 import java.util.stream.Collectors;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,10 +2,13 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
+import java.util.stream.Collectors;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -38,21 +41,63 @@ public class ParserUtil {
     public static String[] tokenize(String args) {
         requireNonNull(args);
         String trimmedArgs = args.trim();
-        return trimmedArgs.split(" ");
+        return trimmedArgs.split("\\s+");
     }
 
     //@@author alexkmj
     /**
-     * Validates the number of arguments. If number of arguments is not within the bounds,
-     * ParseException will be thrown.
+     * Validates the number of arguments. If number of arguments does not
+     * equal to {@code required}, {@code ParseException} will be thrown.
      *
      * @throws ParseException if the number of arguments is invalid
      */
-    public static void validateNumOfArgs(String[] args, int min, int max) throws ParseException {
+    public static void validateNumOfArgs(Object[] args, int required)
+            throws ParseException {
+        requireNonNull(args);
+
+        validateNumOfArgs(args, required, required);
+    }
+
+    //@@author alexkmj
+    /**
+     * Validates the number of arguments. If number of arguments is not within
+     * the bounds, {@code ParseException} will be thrown.
+     *
+     * @throws ParseException if the number of arguments is invalid
+     */
+    public static void validateNumOfArgs(Object[] args, int min, int max)
+            throws ParseException {
+        requireNonNull(args);
+
         if (args.length < min || args.length > max) {
             throw new ParseException("Invalid number of arguments!"
-                    + "Number of arguments should be more than or equal to " + min
-                    + " and less than or equal to " + max);
+                    + "Number of arguments should be more than or equal to "
+                    + min
+                    + " and less than or equal to "
+                    + max);
+        }
+    }
+
+    //@@author alexkmj
+    /**
+     * Validates the number of arguments. If number of arguments is not within
+     * the {@code setOfAllowedNumOfArgs}, {@code ParseException} is thrown.
+     *
+     * @throws ParseException if the number of arguments is not within the
+     * {@code setOfAllowedNumOfArgs}
+     */
+    public static void validateNumOfArgs(Object[] args,
+            HashSet<Integer> setOfAllowedNumOfArgs) throws ParseException {
+        requireNonNull(args);
+
+        if (!setOfAllowedNumOfArgs.contains(args.length)) {
+            String allowedNumOfArgs = setOfAllowedNumOfArgs.stream()
+                    .map(Objects::toString)
+                    .collect(Collectors.joining(", "));
+
+            throw new ParseException("Invalid number of arguments!"
+                    + "Number of arguments should be "
+                    + allowedNumOfArgs);
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -47,16 +47,12 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void validateNumOfArgsValid() throws Exception {
+    public void validateNumOfArgs() throws Exception {
         String[] tokenized = {"a", "b", "c", "d"};
+
         ParserUtil.validateNumOfArgs(tokenized, 4);
         ParserUtil.validateNumOfArgs(tokenized, Integer.MIN_VALUE, 4);
         ParserUtil.validateNumOfArgs(tokenized, 4, Integer.MAX_VALUE);
-    }
-
-    @Test
-    public void validateNumOfArgsThrowsException() throws Exception {
-        String[] tokenized = {"a", "b", "c", "d"};
 
         thrown.expect(ParseException.class);
         ParserUtil.validateNumOfArgs(tokenized, 5, Integer.MAX_VALUE);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,208 +1,87 @@
 package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import static seedu.address.testutil.TypicalModules.ASKING_QUESTIONS;
+import static seedu.address.testutil.TypicalModules.CODE_ASKING_QUESTIONS;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.module.Code;
 import seedu.address.testutil.Assert;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_PHONE = "+651234";
-    private static final String INVALID_ADDRESS = " ";
-    private static final String INVALID_EMAIL = "example.com";
-    private static final String INVALID_TAG = "#friend";
-
-    private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
-    private static final String VALID_ADDRESS = "123 Main Street #0505";
-    private static final String VALID_EMAIL = "rachel@example.com";
-    private static final String VALID_TAG_1 = "friend";
-    private static final String VALID_TAG_2 = "neighbour";
-
-    private static final String WHITESPACE = " \t\r\n";
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void parseIndex_invalidInput_throwsParseException() throws Exception {
+    public void parseTokenizeNullThrowsNullPointerException() throws Exception {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.tokenize(null));
+    }
+
+    @Test
+    public void parseTokenizeSplitsSuccess() {
+        String[] expected = {"a", "b", "c", "d", "e", "f", "g", "h", "i"};
+        String[] tokenized = ParserUtil.tokenize("   a                        "
+                + "b \t "
+                + "c \r"
+                + "d \n"
+                + "e \t\r"
+                + "f \t\n"
+                + "g \r\n h"
+                + "\t\r\n i");
+
+        assertEquals(expected[0], tokenized[0]);
+        assertEquals(expected[1], tokenized[1]);
+        assertEquals(expected[2], tokenized[2]);
+        assertEquals(expected[3], tokenized[3]);
+        assertEquals(expected[4], tokenized[4]);
+        assertEquals(expected[5], tokenized[5]);
+        assertEquals(expected[6], tokenized[6]);
+        assertEquals(expected[7], tokenized[7]);
+        assertEquals(expected[8], tokenized[8]);
+    }
+
+    @Test
+    public void validateNumOfArgsValid() throws Exception {
+        String[] tokenized = {"a", "b", "c", "d"};
+        ParserUtil.validateNumOfArgs(tokenized, 4);
+        ParserUtil.validateNumOfArgs(tokenized, Integer.MIN_VALUE, 4);
+        ParserUtil.validateNumOfArgs(tokenized, 4, Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void validateNumOfArgsThrowsException() throws Exception {
+        String[] tokenized = {"a", "b", "c", "d"};
+
         thrown.expect(ParseException.class);
-        ParserUtil.parseIndex("10 a");
-    }
+        ParserUtil.validateNumOfArgs(tokenized, 5, Integer.MAX_VALUE);
 
-    @Test
-    public void parseIndex_outOfRangeInput_throwsParseException() throws Exception {
         thrown.expect(ParseException.class);
-        thrown.expectMessage(MESSAGE_INVALID_INDEX);
-        ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1));
+        ParserUtil.validateNumOfArgs(tokenized, Integer.MAX_VALUE, 3);
     }
 
     @Test
-    public void parseIndex_validInput_success() throws Exception {
-        // No whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
-
-        // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+    public void parseCodeNullThrowsNullPointerException() throws Exception {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseCode(null));
     }
 
     @Test
-    public void parseName_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseName((String) null));
+    public void parseCodeValid() throws Exception {
+        Code geqCode = ParserUtil.parseCode(CODE_ASKING_QUESTIONS);
+        assertEquals(geqCode, ASKING_QUESTIONS.getCode());
+
+        Code geqCodeLowerCase = ParserUtil.parseCode(CODE_ASKING_QUESTIONS.toLowerCase());
+        assertEquals(geqCodeLowerCase, ASKING_QUESTIONS.getCode());
     }
 
     @Test
-    public void parseName_invalidValue_throwsParseException() {
-        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseName(INVALID_NAME));
-    }
-
-    @Test
-    public void parseName_validValueWithoutWhitespace_returnsName() throws Exception {
-        Name expectedName = new Name(VALID_NAME);
-        assertEquals(expectedName, ParserUtil.parseName(VALID_NAME));
-    }
-
-    @Test
-    public void parseName_validValueWithWhitespace_returnsTrimmedName() throws Exception {
-        String nameWithWhitespace = WHITESPACE + VALID_NAME + WHITESPACE;
-        Name expectedName = new Name(VALID_NAME);
-        assertEquals(expectedName, ParserUtil.parseName(nameWithWhitespace));
-    }
-
-    @Test
-    public void parsePhone_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parsePhone((String) null));
-    }
-
-    @Test
-    public void parsePhone_invalidValue_throwsParseException() {
-        Assert.assertThrows(ParseException.class, () -> ParserUtil.parsePhone(INVALID_PHONE));
-    }
-
-    @Test
-    public void parsePhone_validValueWithoutWhitespace_returnsPhone() throws Exception {
-        Phone expectedPhone = new Phone(VALID_PHONE);
-        assertEquals(expectedPhone, ParserUtil.parsePhone(VALID_PHONE));
-    }
-
-    @Test
-    public void parsePhone_validValueWithWhitespace_returnsTrimmedPhone() throws Exception {
-        String phoneWithWhitespace = WHITESPACE + VALID_PHONE + WHITESPACE;
-        Phone expectedPhone = new Phone(VALID_PHONE);
-        assertEquals(expectedPhone, ParserUtil.parsePhone(phoneWithWhitespace));
-    }
-
-    @Test
-    public void parseAddress_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseAddress((String) null));
-    }
-
-    @Test
-    public void parseAddress_invalidValue_throwsParseException() {
-        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseAddress(INVALID_ADDRESS));
-    }
-
-    @Test
-    public void parseAddress_validValueWithoutWhitespace_returnsAddress() throws Exception {
-        Address expectedAddress = new Address(VALID_ADDRESS);
-        assertEquals(expectedAddress, ParserUtil.parseAddress(VALID_ADDRESS));
-    }
-
-    @Test
-    public void parseAddress_validValueWithWhitespace_returnsTrimmedAddress() throws Exception {
-        String addressWithWhitespace = WHITESPACE + VALID_ADDRESS + WHITESPACE;
-        Address expectedAddress = new Address(VALID_ADDRESS);
-        assertEquals(expectedAddress, ParserUtil.parseAddress(addressWithWhitespace));
-    }
-
-    @Test
-    public void parseEmail_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseEmail((String) null));
-    }
-
-    @Test
-    public void parseEmail_invalidValue_throwsParseException() {
-        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseEmail(INVALID_EMAIL));
-    }
-
-    @Test
-    public void parseEmail_validValueWithoutWhitespace_returnsEmail() throws Exception {
-        Email expectedEmail = new Email(VALID_EMAIL);
-        assertEquals(expectedEmail, ParserUtil.parseEmail(VALID_EMAIL));
-    }
-
-    @Test
-    public void parseEmail_validValueWithWhitespace_returnsTrimmedEmail() throws Exception {
-        String emailWithWhitespace = WHITESPACE + VALID_EMAIL + WHITESPACE;
-        Email expectedEmail = new Email(VALID_EMAIL);
-        assertEquals(expectedEmail, ParserUtil.parseEmail(emailWithWhitespace));
-    }
-
-    @Test
-    public void parseTag_null_throwsNullPointerException() throws Exception {
-        thrown.expect(NullPointerException.class);
-        ParserUtil.parseTag(null);
-    }
-
-    @Test
-    public void parseTag_invalidValue_throwsParseException() throws Exception {
-        thrown.expect(ParseException.class);
-        ParserUtil.parseTag(INVALID_TAG);
-    }
-
-    @Test
-    public void parseTag_validValueWithoutWhitespace_returnsTag() throws Exception {
-        Tag expectedTag = new Tag(VALID_TAG_1);
-        assertEquals(expectedTag, ParserUtil.parseTag(VALID_TAG_1));
-    }
-
-    @Test
-    public void parseTag_validValueWithWhitespace_returnsTrimmedTag() throws Exception {
-        String tagWithWhitespace = WHITESPACE + VALID_TAG_1 + WHITESPACE;
-        Tag expectedTag = new Tag(VALID_TAG_1);
-        assertEquals(expectedTag, ParserUtil.parseTag(tagWithWhitespace));
-    }
-
-    @Test
-    public void parseTags_null_throwsNullPointerException() throws Exception {
-        thrown.expect(NullPointerException.class);
-        ParserUtil.parseTags(null);
-    }
-
-    @Test
-    public void parseTags_collectionWithInvalidTags_throwsParseException() throws Exception {
-        thrown.expect(ParseException.class);
-        ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, INVALID_TAG));
-    }
-
-    @Test
-    public void parseTags_emptyCollection_returnsEmptySet() throws Exception {
-        assertTrue(ParserUtil.parseTags(Collections.emptyList()).isEmpty());
-    }
-
-    @Test
-    public void parseTags_collectionWithValidTags_returnsTagSet() throws Exception {
-        Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, VALID_TAG_2));
-        Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
-
-        assertEquals(expectedTagSet, actualTagSet);
+    public void parseCodeInvalid() throws Exception {
+        Code geqCode = ParserUtil.parseCode(CODE_ASKING_QUESTIONS);
+        assertEquals(geqCode, ASKING_QUESTIONS.getCode());
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalModules.java
+++ b/src/test/java/seedu/address/testutil/TypicalModules.java
@@ -16,55 +16,80 @@ import seedu.address.model.util.ModuleBuilder;
 public class TypicalModules {
     // Manually added
 
-    public static final Double MODULES_WITHOUT_NON_AFFECTING_MODULES_CAP = 3.0;
+    public static final String CODE_ASKING_QUESTIONS = "GEQ1000";
+    public static final String CODE_DATABASE_SYSTEMS = "CS2102";
+    public static final String CODE_DATABASE_SYSTEMS_REDUCED = "CS2102B";
+    public static final String CODE_DATA_STRUCTURES = "CS2040";
+    public static final String CODE_DISCRETE_MATH = "CS1231";
+    public static final String CODE_SOFTWARE_ENGINEERING = "CS1231";
+    public static final String CODE_PROGRAMMING_METHODOLOGY = "CS2030";
 
-    public static final Module DISCRETE_MATH = new ModuleBuilder().withCode("CS1231")
-            .withYear(1)
+    public static final int YEAR_ONE = 1;
+    public static final int YEAR_TWO = 2;
+    public static final int YEAR_THREE = 3;
+
+    public static final String GRADE_A_PLUS = "A+";
+    public static final String GRADE_B_PLUS = "B+";
+    public static final String GRADE_F = "F";
+    public static final String GRADE_CS = "CS";
+
+    public static final int CREDIT_TWO = 2;
+    public static final int CREDIT_FOUR = 4;
+
+    public static final Module DISCRETE_MATH = new ModuleBuilder()
+            .withCode(CODE_DISCRETE_MATH)
+            .withYear(YEAR_ONE)
             .withSemester(Semester.SEMESTER_ONE)
-            .withCredit(4)
-            .withGrade("A+")
+            .withCredit(CREDIT_FOUR)
+            .withGrade(GRADE_A_PLUS)
             .build();
 
-    public static final Module PROGRAMMING_METHODOLOGY_TWO = new ModuleBuilder().withCode("CS2030")
-            .withYear(2)
+    public static final Module PROGRAMMING_METHODOLOGY_TWO = new ModuleBuilder()
+            .withCode(CODE_PROGRAMMING_METHODOLOGY)
+            .withYear(YEAR_TWO)
             .withSemester(Semester.SEMESTER_TWO)
-            .withCredit(4)
-            .withGrade("B+")
+            .withCredit(CREDIT_FOUR)
+            .withGrade(GRADE_B_PLUS)
             .build();
 
-    public static final Module DATA_STRUCTURES = new ModuleBuilder().withCode("CS2040")
-            .withYear(3)
+    public static final Module DATA_STRUCTURES = new ModuleBuilder()
+            .withCode(CODE_DATA_STRUCTURES)
+            .withYear(YEAR_THREE)
             .withSemester(Semester.SEMESTER_SPECIAL_ONE)
-            .withCredit(4)
-            .withGrade("F")
+            .withCredit(CREDIT_FOUR)
+            .withGrade(GRADE_F)
             .build();
 
-    public static final Module ASKING_QUESTIONS = new ModuleBuilder().withCode("GEQ1000")
-            .withYear(1)
+    public static final Module ASKING_QUESTIONS = new ModuleBuilder()
+            .withCode(CODE_ASKING_QUESTIONS)
+            .withYear(YEAR_ONE)
             .withSemester(Semester.SEMESTER_ONE)
-            .withCredit(4)
-            .withGrade("CS")
+            .withCredit(CREDIT_FOUR)
+            .withGrade(GRADE_CS)
             .build();
 
-    public static final Module SOFTWARE_ENGINEERING = new ModuleBuilder().withCode("CS2103")
-            .withYear(3)
+    public static final Module SOFTWARE_ENGINEERING = new ModuleBuilder()
+            .withCode(CODE_SOFTWARE_ENGINEERING)
+            .withYear(YEAR_THREE)
             .withSemester(Semester.SEMESTER_ONE)
-            .withCredit(4)
-            .withGrade("A+")
+            .withCredit(CREDIT_FOUR)
+            .withGrade(GRADE_A_PLUS)
             .build();
 
-    public static final Module DATABASE_SYSTEMS = new ModuleBuilder().withCode("CS2102")
-            .withYear(2)
+    public static final Module DATABASE_SYSTEMS = new ModuleBuilder()
+            .withCode(CODE_DATABASE_SYSTEMS)
+            .withYear(YEAR_TWO)
             .withSemester(Semester.SEMESTER_ONE)
-            .withCredit(4)
-            .withGrade("A+")
+            .withCredit(CREDIT_FOUR)
+            .withGrade(GRADE_A_PLUS)
             .build();
 
-    public static final Module DATABASE_SYSTEMS_2MC = new ModuleBuilder().withCode("CS2102B")
-            .withYear(2)
+    public static final Module DATABASE_SYSTEMS_2MC = new ModuleBuilder()
+            .withCode(CODE_DATABASE_SYSTEMS_REDUCED)
+            .withYear(YEAR_TWO)
             .withSemester(Semester.SEMESTER_ONE)
-            .withCredit(2)
-            .withGrade("A+")
+            .withCredit(CREDIT_TWO)
+            .withGrade(GRADE_A_PLUS)
             .build();
 
     /**

--- a/src/test/java/seedu/address/testutil/TypicalModules.java
+++ b/src/test/java/seedu/address/testutil/TypicalModules.java
@@ -15,6 +15,7 @@ import seedu.address.model.util.ModuleBuilder;
  */
 public class TypicalModules {
     // Manually added
+    public static final Double MODULES_WITHOUT_NON_AFFECTING_MODULES_CAP = 3.0;
 
     public static final String CODE_ASKING_QUESTIONS = "GEQ1000";
     public static final String CODE_DATABASE_SYSTEMS = "CS2102";


### PR DESCRIPTION
# Fix bug for ParserUtil.tokenizer
Tokenizer does not split properly with multiple white-spaces or non space white-spaces. This PR address this issue and adds test cases for it.

# Enforce use of constants in TestUtil.TypicalModules
Static codes, year, credit, and grade has been added and modules in typical module will use them instead of defining it again. Hopefully we can change the other tests to use the constants instead of redefining it again all over and having to change them again from everywhere whenever there is a change in `Code`, `Year`, `Credit`, or `Grade`

Fixes #115
Fixes #114