### PR TITLE
Add now uses name value pair

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
@@ -52,7 +52,7 @@ public class AddModuleCommand extends Command {
         model.commitTranscript();
 
         // Return success message.
-        String successMsg = String.format(MESSAGE_ADD_SUCCESS, tooAdd);
+        String successMsg = String.format(MESSAGE_ADD_SUCCESS, toAdd);
         return new CommandResult(successMsg);
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -11,8 +12,16 @@ import seedu.address.model.module.Module;
  * Adds a module to the transcript.
  */
 public class AddModuleCommand extends Command {
+    /**
+     * Command word for {@code AddModuleCommand}.
+     */
     public static final String COMMAND_WORD = "add";
 
+    /**
+     * Usage of <b>add</b>.
+     * <p>
+     * Provides the description and syntax of <b>add</b>.
+     */
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": "
             + "Adds a module.\n"
             + "Parameters: "
@@ -22,11 +31,20 @@ public class AddModuleCommand extends Command {
             + "-c CREDIT "
             + "[-g GRADE]";
 
-    // Constants for CommandException.
+    /**
+     * Message that informs that new module is added successfully.
+     */
     public static final String MESSAGE_ADD_SUCCESS = "New module add: %1$s";
+
+    /**
+     * Message that informs that new module already exist.
+     */
     public static final String MESSAGE_MODULE_ALREADY_EXIST = "New module"
             + " already exist.";
 
+    /**
+     * Module to be added.
+     */
     private final Module toAdd;
 
     /**
@@ -38,6 +56,17 @@ public class AddModuleCommand extends Command {
         toAdd = module;
     }
 
+    /**
+     * Adds a module into the module list of transcript.
+     * <p>
+     * Throws {@code CommandException} when module to be added already exist.
+     *
+     * @param model {@code Model} that the command operates on.
+     * @param history {@code CommandHistory} that the command operates on.
+     * @return result of the command
+     * @throws CommandException thrown when command cannot be executed
+     * successfully
+     */
     @Override
     public CommandResult execute(Model model, CommandHistory history)
             throws CommandException {
@@ -71,10 +100,26 @@ public class AddModuleCommand extends Command {
         }
     }
 
+    /**
+     * Returns true if all {@code toAdd} matches.
+     *
+     * @param other the other object compared against
+     * @return true if all field matches
+     */
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof AddModuleCommand // instanceof handles nulls
-                && toAdd.equals(((AddModuleCommand) other).toAdd));
+        // Short circuit if same object.
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls.
+        if (!(other instanceof AddModuleCommand)) {
+            return false;
+        }
+
+        // State check.
+        AddModuleCommand e = (AddModuleCommand) other;
+        return Objects.equals(toAdd, e.toAdd);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
@@ -11,21 +11,27 @@ import seedu.address.model.module.Module;
  * Adds a module to the transcript.
  */
 public class AddModuleCommand extends Command {
-
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to the transcript. "
-            + "Parameters: CODE YEAR SEMESTER CREDIT [GRADE]"
-            + "Example: " + COMMAND_WORD + " CS2103 2 1 4 A+";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": "
+            + "Adds a module.\n"
+            + "Parameters: "
+            + "-m MODULE_CODE "
+            + "-y YEAR "
+            + "-s SEMESTER "
+            + "-c CREDIT "
+            + "[-g GRADE]";
 
-    public static final String MESSAGE_SUCCESS = "New module added: %1$s";
-    public static final String MESSAGE_DUPLICATE_MODULE =
-            "This module already exists in the transcript";
+    // Constants for CommandException.
+    public static final String MESSAGE_ADD_SUCCESS = "New module add: %1$s";
+    public static final String MESSAGE_MODULE_ALREADY_EXIST = "New module"
+            + " already exist.";
 
     private final Module toAdd;
 
     /**
-     * Creates an AddModuleCommand to add the specified {@code Module}
+     * Constructor that instantiates {@code AddModuleCommand}.
+     * @param module
      */
     public AddModuleCommand(Module module) {
         requireNonNull(module);
@@ -33,16 +39,36 @@ public class AddModuleCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+    public CommandResult execute(Model model, CommandHistory history)
+            throws CommandException {
+        // Model cannot be null.
         requireNonNull(model);
 
-        if (model.hasModule(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_MODULE);
-        }
+        // Throws CommandException if module already exists.
+        editedModuleExist(model, toAdd);
 
+        // Add module and commit.
         model.addModule(toAdd);
         model.commitTranscript();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+
+        // Return success message.
+        String successMsg = String.format(MESSAGE_ADD_SUCCESS, tooAdd);
+        return new CommandResult(successMsg);
+    }
+
+    /**
+     * Throws {@code CommandException} if {@code toAdd} already exist.
+     *
+     * @param model {@code Model} that the command operates on.
+     * @param toAdd module to be added
+     * @throws CommandException thrown if {@code toAdd} already exist
+     */
+    private void editedModuleExist(Model model, Module toAdd)
+            throws CommandException {
+
+        if (model.hasModule(toAdd)) {
+            throw new CommandException(MESSAGE_MODULE_ALREADY_EXIST);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/parser/AddModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddModuleCommandParser.java
@@ -1,8 +1,24 @@
 package seedu.address.logic.parser;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toSet;
+import static seedu.address.logic.parser.ParserUtil.argsAreNameValuePair;
 import static seedu.address.logic.parser.ParserUtil.argsWithBounds;
+import static seedu.address.logic.parser.ParserUtil.targetCodeNotNull;
+import static seedu.address.logic.parser.ParserUtil.targetYearNullIffTargetSemesterNull;
+import static seedu.address.logic.parser.ParserUtil.validateName;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
 import seedu.address.logic.commands.AddModuleCommand;
+import seedu.address.logic.commands.DeleteModuleCommand;
+import seedu.address.logic.parser.arguments.AddArgument;
+import seedu.address.logic.parser.arguments.DeleteArgument;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Code;
 import seedu.address.model.module.Credit;
@@ -16,32 +32,141 @@ import seedu.address.model.module.Year;
  * Parses input arguments and creates a new AddModuleCommand object
  */
 public class AddModuleCommandParser implements Parser<AddModuleCommand> {
+    /**
+     * Message that informs that the command is in a wrong format and
+     * prints the usage for delete command.
+     */
+    public static final String MESSAGE_INVALID_FORMAT =
+            ParserUtil.MESSAGE_INVALID_FORMAT
+                    + "\n"
+                    + DeleteModuleCommand.MESSAGE_USAGE;
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddModuleCommand
-     * and returns an AddModuleCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * Immutable map that maps string argument to edit argument enum.
      */
-    public AddModuleCommand parse(String args) throws ParseException {
-        String[] tokenizedArgs = ParserUtil.tokenize(args);
-        argsWithBounds(tokenizedArgs, 4, 5);
+    private static final Map<String, AddArgument> NAME_TO_ARGUMENT_MAP;
 
-        int index = 0;
+    /**
+     * Immutable set containing the allowable size of arguments.
+     */
+    private static final Set<Integer> ALLOWED_ARG_SIZE;
 
-        Code code = ParserUtil.parseCode(tokenizedArgs[index++]);
-        Year year = ParserUtil.parseYear(tokenizedArgs[index++]);
-        Semester semester = ParserUtil.parseSemester(tokenizedArgs[index++]);
-        Credit credit = ParserUtil.parseCredit(tokenizedArgs[index++]);
+    static {
+        Map<String, AddArgument> map = new HashMap<>();
+        for (AddArgument instance : AddArgument.values()) {
+            map.put(instance.getShortName(), instance);
+            map.put(instance.getLongName(), instance);
+        }
+        NAME_TO_ARGUMENT_MAP = Collections.unmodifiableMap(map);
+    }
 
-        Module module = null;
+    /**
+     * Populate {@code ALLOWED_ARG_SIZE} with a set of numbers representing the
+     * allowed argument sizes.
+     */
+    static {
+        ALLOWED_ARG_SIZE = IntStream.range(8, 11)
+                .filter(index -> index % 2 == 0)
+                .boxed()
+                .collect(collectingAndThen(toSet(), ImmutableSet::copyOf));
+    }
 
-        if (tokenizedArgs.length == 4) {
-            module = new Module(code, year, semester, credit, null, false);
-        } else {
-            Grade grade = ParserUtil.parseGrade(tokenizedArgs[index++]);
-            module = new Module(code, year, semester, credit, grade, true);
+    /**
+     * Parses {@code args} in the context of {@code DeleteModuleCommand} and
+     * returns {@code DeleteModuleCommand} for execution.
+     * <p>
+     * Throws {@code ParseException} when:
+     * <ul>
+     *     <li>Number of argument is not between 2 and 6.</li>
+     *     <li>Number of argument is not even.</li>
+     *     <li>Argument is not in name-value pair format</li>
+     *     <li>Argument contains illegal name</li>
+     *     <li>Same name appeared more than once</li>
+     *     <li>Target code is not provided.</li>
+     *     <li>Target year is provided but target semester is not provided.</li>
+     *     <li>Target semester is provided but target year is not provided.</li>
+     * </ul>
+     *
+     * @param argsInString String that contains all the argument
+     * @return {@code EditModuleCommand} object for execution
+     * @throws ParseException thrown when user input does not conform to the
+     * expected format
+     */
+    public AddModuleCommand parse(String argsInString)
+            throws ParseException {
+        // Converts argument string to tokenize argument array.
+        String[] args = ParserUtil.tokenize(argsInString);
+
+        // Size of argument should be 8 or 10.
+        // Arguments should be in name-value pair.
+        // Name should be legal.
+        // No duplicate name.
+        argsWithBounds(args, ALLOWED_ARG_SIZE);
+        argsAreNameValuePair(args, MESSAGE_INVALID_FORMAT);
+        validateName(args, NAME_TO_ARGUMENT_MAP, MESSAGE_INVALID_FORMAT);
+
+        // Map the object of the parsed value to {@code AddArgument}
+        // instance.
+        // Code, Year, Semeter, and Credit should not be null.
+        EnumMap<AddArgument, Object> argMap = parseValues(args);
+        onlyGradeCanBeNull(argMap);
+        Module newModule = getModuleWithAddArgMap(argMap);
+
+        // Return delete module command for execution.
+        return new AddModuleCommand(newModule);
+    }
+
+    /**
+     * Parse the value into its relevant object and put it in {@code argMap}.
+     *
+     * @param args array of name-value pair arguments
+     * @throws ParseException thrown when the value cannot be parsed
+     */
+    private EnumMap<AddArgument, Object> parseValues(String[] args)
+            throws ParseException {
+        // Initialise argument map.
+        EnumMap<AddArgument, Object> argMap =
+                new EnumMap<>(AddArgument.class);
+
+        for (int index = 0; index < args.length; index = index + 2) {
+            AddArgument name = NAME_TO_ARGUMENT_MAP.get(args[index]);
+            Object value = name.getValue(args[index + 1]);
+            argMap.put(name, value);
         }
 
-        return new AddModuleCommand(module);
+        return argMap;
+    }
+
+    private static void onlyGradeCanBeNull(EnumMap<AddArgument, Object> argMap)
+            throws ParseException {
+        boolean codeIsNull = argMap.get(AddArgument.NEW_CODE) == null;
+        boolean yearIsNull = argMap.get(AddArgument.NEW_YEAR) == null;
+        boolean semesterIsNull = argMap.get(AddArgument.NEW_SEMESTER) == null;
+        boolean creditIsNull = argMap.get(AddArgument.NEW_CREDIT) == null;
+
+        if (codeIsNull || yearIsNull || semesterIsNull || creditIsNull) {
+            throw new ParseException(MESSAGE_INVALID_FORMAT);
+        }
+    }
+
+    /**
+     * Creates and returns a module instance based on {@code argMap}.
+     *
+     * @param argMap add argument map used to create module instance
+     * @return module instance based on {@code argMap}
+     */
+    private static Module getModuleWithAddArgMap(
+            EnumMap<AddArgument, Object> argMap) {
+        Code code = (Code) argMap.get(AddArgument.NEW_CODE);
+        Year year = (Year) argMap.get(AddArgument.NEW_YEAR);
+        Semester semester = (Semester) argMap.get(AddArgument.NEW_SEMESTER);
+        Credit credit = (Credit) argMap.get(AddArgument.NEW_CREDIT);
+        Grade grade = (Grade) argMap.get(AddArgument.NEW_GRADE);
+
+        if (grade == null) {
+            return new Module(code, year, semester, credit, null, false);
+        }
+
+        return new Module(code, year, semester, credit, grade, true);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddModuleCommandParser.java
@@ -4,21 +4,20 @@ import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toSet;
 import static seedu.address.logic.parser.ParserUtil.argsAreNameValuePair;
 import static seedu.address.logic.parser.ParserUtil.argsWithBounds;
-import static seedu.address.logic.parser.ParserUtil.targetCodeNotNull;
-import static seedu.address.logic.parser.ParserUtil.targetYearNullIffTargetSemesterNull;
 import static seedu.address.logic.parser.ParserUtil.validateName;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
+
+import com.google.common.collect.ImmutableSet;
+
 import seedu.address.logic.commands.AddModuleCommand;
 import seedu.address.logic.commands.DeleteModuleCommand;
 import seedu.address.logic.parser.arguments.AddArgument;
-import seedu.address.logic.parser.arguments.DeleteArgument;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Code;
 import seedu.address.model.module.Credit;
@@ -109,7 +108,7 @@ public class AddModuleCommandParser implements Parser<AddModuleCommand> {
         // instance.
         // Code, Year, Semeter, and Credit should not be null.
         EnumMap<AddArgument, Object> argMap = parseValues(args);
-        onlyGradeCanBeNull(argMap);
+        onlyGradeCanBeEmpty(argMap);
         Module newModule = getModuleWithAddArgMap(argMap);
 
         // Return delete module command for execution.
@@ -137,7 +136,14 @@ public class AddModuleCommandParser implements Parser<AddModuleCommand> {
         return argMap;
     }
 
-    private static void onlyGradeCanBeNull(EnumMap<AddArgument, Object> argMap)
+    /**
+     * Only grade argument can be empty.
+     *
+     * @param argMap add argument map used to create module instance
+     * @throws ParseException thrown when code, year, semester, or credit is
+     * null
+     */
+    private static void onlyGradeCanBeEmpty(EnumMap<AddArgument, Object> argMap)
             throws ParseException {
         boolean codeIsNull = argMap.get(AddArgument.NEW_CODE) == null;
         boolean yearIsNull = argMap.get(AddArgument.NEW_YEAR) == null;

--- a/src/main/java/seedu/address/logic/parser/arguments/AddArgument.java
+++ b/src/main/java/seedu/address/logic/parser/arguments/AddArgument.java
@@ -1,0 +1,126 @@
+package seedu.address.logic.parser.arguments;
+
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Basic enum for AddArgument.
+ */
+public enum AddArgument {
+    NEW_CODE('m', "code") {
+        /**
+         * Parses value into code.
+         *
+         * @param value new code in string
+         * @return {@code Code} cast into {@code Object}
+         * @throws ParseException Thrown when code cannot be parsed
+         */
+        @Override
+        public Object getValue(String value) throws ParseException {
+            return ParserUtil.parseCode(value);
+        }
+    },
+    NEW_YEAR('y', "year") {
+        /**
+         * Parses value into year.
+         *
+         * @param value new year in string
+         * @return {@code Year} cast into {@code Object}
+         * @throws ParseException Thrown when year cannot be parsed
+         */
+        @Override
+        public Object getValue(String value) throws ParseException {
+            return ParserUtil.parseYear(value);
+        }
+    },
+    NEW_SEMESTER('s', "semester") {
+        /**
+         * Parses value into semester.
+         *
+         * @param value new semester in string
+         * @return {@code Semester} cast into {@code Object}
+         * @throws ParseException Thrown when semester cannot be parsed
+         */
+        @Override
+        public Object getValue(String value) throws ParseException {
+            return ParserUtil.parseSemester(value);
+        }
+    },
+    NEW_CREDIT('c', "credit") {
+        /**
+         * Parses value into credit.
+         *
+         * @param value new credit in string
+         * @return {@code Credit} cast into {@code Object}
+         * @throws ParseException Thrown when credit cannot be parsed
+         */
+        @Override
+        public Object getValue(String value) throws ParseException {
+            return ParserUtil.parseCredit(value);
+        }
+    },
+    NEW_GRADE('g', "grade") {
+        /**
+         * Parses value into grade.
+         *
+         * @param value new grade in string
+         * @return {@code Grade} cast into {@code Object}
+         * @throws ParseException Thrown when grade cannot be parsed
+         */
+        @Override
+        public Object getValue(String value) throws ParseException {
+            return ParserUtil.parseGrade(value);
+        }
+    };
+
+    /**
+     * A character that represents the name for the particular name-value pair.
+     */
+    private char shortName;
+
+    /**
+     * A string that represents the name for a the particular name-value pair.
+     */
+    private String longName;
+
+    /**
+     * Constructor that takes in the short name and long name.
+     *
+     * @param shortName short name of the name of a name-value pair
+     * @param longName long name of the name of a name-value pair
+     */
+    AddArgument(char shortName, String longName) {
+        this.shortName = shortName;
+        this.longName = longName;
+    }
+
+    /**
+     * Returns the short name of a name-value pair. It is a prefix and a
+     * character representing the name.
+     *
+     * @return short name of the name-value pair
+     */
+    public String getShortName() {
+        return ParserUtil.NAME_PREFIX_SHORT + shortName;
+    }
+
+    /**
+     * Returns the long name of a name-value pair. It is a long prefix and a
+     * string representing the name.
+     *
+     * @return long name of the name-value pair
+     */
+    public String getLongName() {
+        return ParserUtil.NAME_PREFIX_LONG + longName;
+    }
+
+    /**
+     * Returns null.
+     * <p>
+     * Overwritten by the specific variable that will return the object
+     * associated to it.
+     */
+    public Object getValue(String value) throws ParseException {
+        return null;
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddModuleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddModuleCommandTest.java
@@ -49,7 +49,7 @@ public class AddModuleCommandTest {
         CommandResult commandResult = new AddModuleCommand(validModule)
                 .execute(modelStub, commandHistory);
 
-        assertEquals(String.format(AddModuleCommand.MESSAGE_SUCCESS, validModule),
+        assertEquals(String.format(AddModuleCommand.MESSAGE_ADD_SUCCESS, validModule),
                 commandResult.feedbackToUser);
         assertEquals(Arrays.asList(validModule), modelStub.modulesAdded);
         assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
@@ -62,7 +62,7 @@ public class AddModuleCommandTest {
         ModelStub modelStub = new ModelStubWithModule(validModule);
 
         thrown.expect(CommandException.class);
-        thrown.expectMessage(AddModuleCommand.MESSAGE_DUPLICATE_MODULE);
+        thrown.expectMessage(AddModuleCommand.MESSAGE_MODULE_ALREADY_EXIST);
         addCommand.execute(modelStub, commandHistory);
     }
 
@@ -75,7 +75,7 @@ public class AddModuleCommandTest {
         ModelStub modelStub = new ModelStubWithModule(validModuleComplete);
 
         thrown.expect(CommandException.class);
-        thrown.expectMessage(AddModuleCommand.MESSAGE_DUPLICATE_MODULE);
+        thrown.expectMessage(AddModuleCommand.MESSAGE_MODULE_ALREADY_EXIST);
         addCommand.execute(modelStub, commandHistory);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddModuleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddModuleCommandParserTest.java
@@ -1,30 +1,82 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalModules.DISCRETE_MATH;
 
 import org.junit.Test;
 
 import seedu.address.logic.commands.AddModuleCommand;
+import seedu.address.model.module.Code;
+import seedu.address.model.module.Credit;
+import seedu.address.model.module.Grade;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.Semester;
+import seedu.address.model.module.Year;
 import seedu.address.model.util.ModuleBuilder;
+import seedu.address.testutil.Assert;
 
 //@@author alexkmj
+/**
+ * Unit testing for {@code AddModuleCommandParser}.
+ * <p>
+ * Tests for the following:
+ * <ul>
+ *     <li>Argument should not be null</li>
+ *     <li>Number of arguments should be 8 or 10</li>
+ *     <li>Only grade can be null</li>
+ * </ul>
+ */
 public class AddModuleCommandParserTest {
+    /**
+     * {@code AddModuleCommandParser} instance used for parsing arguments in
+     * {@code AddModuleCommandParserTest}.
+     */
     private AddModuleCommandParser parser = new AddModuleCommandParser();
 
+    /**
+     * Argument cannot be null.
+     */
     @Test
-    public void parseAllFieldsPresentSuccess() throws Exception {
-        // leading and trailing whitespace
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE
-                + " " + DISCRETE_MATH.getCode().value
-                + " " + DISCRETE_MATH.getYear().value
-                + " " + DISCRETE_MATH.getSemester().value
-                + " " + DISCRETE_MATH.getCredits().value
-                + " " + DISCRETE_MATH.getGrade().value, new AddModuleCommand(DISCRETE_MATH));
+    public void parseNullArgumentFails() {
+        Assert.assertThrows(NullPointerException.class, () -> {
+            parser.parse(null);
+        });
     }
 
+    /**
+     * Number of arguments for edit should be more than or equal to 4 and less
+     * than or equal to 16.
+     */
+    @Test
+    public void parseInvalidNumOfArgumentFails() {
+        String exceptionMsg = "Invalid number of arguments! "
+                + "Number of arguments should be 8, 10";
+
+        assertParseFailure(parser, "", exceptionMsg);
+        assertParseFailure(parser, "-m CS1231", exceptionMsg);
+        assertParseFailure(parser, "-m CS1231 -y 1", exceptionMsg);
+        assertParseFailure(parser, "-m CS1231 -y 1 -s 1", exceptionMsg);
+        assertParseFailure(parser,
+                "-m CS1231 -y 1 -s 1 -c 4 -g A+ -extra extra",
+                exceptionMsg);
+    }
+
+    /**
+     * Parse in this unit test should pass.
+     */
+    @Test
+    public void parseAllFieldsPresentSuccess() {
+        // leading and trailing whitespace
+        assertParseSuccess(parser,
+                "-m CS1231 -y 1 -s 1 -c 4 -g A+",
+                new AddModuleCommand(DISCRETE_MATH));
+    }
+
+    /**
+     * Parse in this unit test should pass.
+     */
     @Test
     public void parseOptionalFieldsMissingSuccess() {
         Module expectedModule = new ModuleBuilder(DISCRETE_MATH)
@@ -33,9 +85,8 @@ public class AddModuleCommandParserTest {
                 .build();
 
         // no grade
-        assertParseSuccess(parser, DISCRETE_MATH.getCode().value
-                + " " + DISCRETE_MATH.getYear().value
-                + " " + DISCRETE_MATH.getSemester().value
-                + " " + DISCRETE_MATH.getCredits().value, new AddModuleCommand(expectedModule));
+        assertParseSuccess(parser,
+                "-m CS1231 -y 1 -s 1 -c 4",
+                new AddModuleCommand(expectedModule));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddModuleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddModuleCommandParserTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalModules.DISCRETE_MATH;
@@ -8,12 +7,7 @@ import static seedu.address.testutil.TypicalModules.DISCRETE_MATH;
 import org.junit.Test;
 
 import seedu.address.logic.commands.AddModuleCommand;
-import seedu.address.model.module.Code;
-import seedu.address.model.module.Credit;
-import seedu.address.model.module.Grade;
 import seedu.address.model.module.Module;
-import seedu.address.model.module.Semester;
-import seedu.address.model.module.Year;
 import seedu.address.model.util.ModuleBuilder;
 import seedu.address.testutil.Assert;
 

--- a/src/test/java/seedu/address/testutil/ModuleUtil.java
+++ b/src/test/java/seedu/address/testutil/ModuleUtil.java
@@ -3,6 +3,7 @@ package seedu.address.testutil;
 import seedu.address.logic.commands.AddModuleCommand;
 import seedu.address.logic.commands.DeleteModuleCommand;
 import seedu.address.logic.commands.EditModuleCommand;
+import seedu.address.logic.parser.arguments.AddArgument;
 import seedu.address.logic.parser.arguments.DeleteArgument;
 import seedu.address.logic.parser.arguments.EditArgument;
 import seedu.address.model.module.Code;
@@ -17,25 +18,52 @@ import seedu.address.model.module.Year;
  * A utility class for Module.
  */
 public class ModuleUtil {
+    /**
+     * Returns a edit command string for adding {@code module}.
+     *
+     * @param module {@code module} to be added
+     * @return add command string for adding {@code module}
+     */
+    public static String getAddModuleCommand(Module module) {
+        return getAddModuleCommand(
+                module.getCode(),
+                module.getYear(),
+                module.getSemester(),
+                module.getCredits(),
+                module.getGrade()
+        );
+    }
 
     /**
-     * Returns an add command string for adding the {@code newModule}.
+     * Returns a edit command string for adding module.
      *
-     * @param newModule module to be added
-     * @return add command string for adding {@code newModule}
+     * @param code new {@code Code} object
+     * @param year new {@code Year} object
+     * @param semester new {@code Semester} object
+     * @param credit new {@code Credit} object
+     * @param grade new {@code Grade} object
+     * @return add command string for adding a module
      */
-    public static String getAddModuleCommand(Module newModule) {
-        return AddModuleCommand.COMMAND_WORD
-                + " "
-                + newModule.getCode().value
-                + " "
-                + newModule.getYear().value
-                + " "
-                + newModule.getSemester().value
-                + " "
-                + newModule.getCredits().value
-                + " "
-                + newModule.getGrade().value;
+    public static String getAddModuleCommand(Code code, Year year,
+            Semester semester, Credit credit, Grade grade) {
+        String command = AddModuleCommand.COMMAND_WORD
+                + " " + AddArgument.NEW_CODE.getShortName()
+                + " " + code.value
+                + " " + AddArgument.NEW_YEAR.getShortName()
+                + " " + year.value
+                + " " + AddArgument.NEW_SEMESTER.getShortName()
+                + " " + semester.value
+                + " " + AddArgument.NEW_CREDIT.getShortName()
+                + " " + credit.value
+                + " ";
+
+        if (grade != null) {
+            command += AddArgument.NEW_GRADE.getShortName()
+                    + " " + grade.value
+                    + " ";
+        }
+
+        return command;
     }
 
     /**
@@ -45,7 +73,6 @@ public class ModuleUtil {
      * @return delete command string for deleting {@code target}
      */
     public static String getDeleteModuleCommand(Module target) {
-
         return DeleteModuleCommand.COMMAND_WORD
                 + " " + DeleteArgument.TARGET_CODE.getShortName()
                 + " " + target.getCode().value
@@ -53,6 +80,25 @@ public class ModuleUtil {
                 + " " + target.getYear().value
                 + " " + DeleteArgument.TARGET_SEMESTER.getShortName()
                 + " " + target.getSemester().value;
+    }
+
+    /**
+     * Returns a delete command string for deleting a module.
+     *
+     * @param targetCode module matching the code
+     * @param targetYear if module matching the year if not null
+     * @param targetSemester if module matching the semester if not null
+     * @return delete command for deleting module
+     */
+    public static String getDeleteModuleCommand(Code targetCode,
+            Year targetYear, Semester targetSemester) {
+        return DeleteModuleCommand.COMMAND_WORD
+                + " " + DeleteArgument.TARGET_CODE.getShortName()
+                + " " + targetCode.value
+                + " " + DeleteArgument.TARGET_YEAR.getShortName()
+                + " " + targetYear.value
+                + " " + DeleteArgument.TARGET_SEMESTER.getShortName()
+                + " " + targetSemester.value;
     }
 
     /**
@@ -68,13 +114,39 @@ public class ModuleUtil {
      */
     public static String getEditModuleCommand(Module target, Code code,
             Year year, Semester semester, Credit credit, Grade grade) {
+        return getEditModuleCommand(target.getCode(),
+                target.getYear(),
+                target.getSemester(),
+                code,
+                year,
+                semester,
+                credit,
+                grade);
+    }
+
+    /**
+     * Returns a edit command string for editing module.
+     *
+     * @param targetCode module matching the code
+     * @param targetYear if module matching the year if not null
+     * @param targetSemester if module matching the semester if not null
+     * @param code new {@code Code} object
+     * @param year new {@code Year} object
+     * @param semester new {@code Semester} object
+     * @param credit new {@code Credit} object
+     * @param grade new {@code Grade} object
+     * @return edit command string for editing {@code target}
+     */
+    public static String getEditModuleCommand(Code targetCode, Year targetYear,
+            Semester targetSemester, Code code, Year year, Semester semester,
+            Credit credit, Grade grade) {
         String command = EditModuleCommand.COMMAND_WORD
                 + " " + EditArgument.TARGET_CODE.getShortName()
-                + " " + target.getCode().value
+                + " " + targetCode.value
                 + " " + EditArgument.TARGET_YEAR.getShortName()
-                + " " + target.getYear().value
+                + " " + targetYear.value
                 + " " + EditArgument.TARGET_SEMESTER.getShortName()
-                + " " + target.getSemester().value;
+                + " " + targetSemester.value;
 
         command += " ";
 


### PR DESCRIPTION
## Description
`add` now uses name value pair.

### Name-Value Pair
```
-name1 value1 -name2 value2 -name3 value3 -name4 value4
```

### New usage:
```
add -m MODULE_CODE  -y YEAR -s SEMESTER -c CREDIT [-g GRADE]
```

### For add argument to be valid:
- Number of argument must be 8 and 10.
- Arguments have to be in name-value pair format
- Number of argument is even (because it has to be name-value pair)
- Only grade is optional
- Argument cannot contain illegal name
- Same name cannot appear more than once
- All values can be parsed

Fixes  #172
Fixes #154